### PR TITLE
[#26]  비밀번호 변경 로직 구현

### DIFF
--- a/src/main/java/com/spotlightspace/core/auth/controller/AuthController.java
+++ b/src/main/java/com/spotlightspace/core/auth/controller/AuthController.java
@@ -5,10 +5,12 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import com.spotlightspace.core.auth.dto.SigninUserRequestDto;
 import com.spotlightspace.core.auth.dto.SignupUserRequestDto;
 import com.spotlightspace.core.auth.service.AuthService;
+import com.spotlightspace.core.user.dto.request.UpdatePasswordUserRequestDto;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,5 +41,19 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(AUTHORIZATION, accessToken)
                 .build();
+    }
+
+    /**
+     * 패스워드 변경을 구현했습니다.
+     *
+     * @param updateUserRequestDto 비밀번호와 이메일을 입력받습니다
+     * @return
+     */
+    @PatchMapping("/auth/password")
+    public ResponseEntity<Void> updatePassword(
+            @Valid @RequestBody UpdatePasswordUserRequestDto updateUserRequestDto
+    ) {
+        authService.updatePassword(updateUserRequestDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/spotlightspace/core/auth/service/AuthService.java
+++ b/src/main/java/com/spotlightspace/core/auth/service/AuthService.java
@@ -10,6 +10,7 @@ import com.spotlightspace.core.attachment.service.AttachmentService;
 import com.spotlightspace.core.auth.dto.SigninUserRequestDto;
 import com.spotlightspace.core.auth.dto.SignupUserRequestDto;
 import com.spotlightspace.core.user.domain.User;
+import com.spotlightspace.core.user.dto.request.UpdatePasswordUserRequestDto;
 import com.spotlightspace.core.user.repository.UserRepository;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional
 @RequiredArgsConstructor
 public class AuthService {
+
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
@@ -39,8 +41,8 @@ public class AuthService {
 
         User savedUser = userRepository.save(user);
 
-        if(file != null) {
-            attachmentService.addAttachment(file,savedUser.getId(), TableRole.USER);
+        if (file != null) {
+            attachmentService.addAttachment(file, savedUser.getId(), TableRole.USER);
         }
 
         return jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), savedUser.getRole());
@@ -54,12 +56,20 @@ public class AuthService {
             throw new ApplicationException(ErrorCode.INVALID_PASSWORD_OR_EMAIL);
         }
 
-        if(user.isDeleted())
-        {
+        if (user.isDeleted()) {
             throw new ApplicationException(USER_NOT_FOUND);
         }
 
         return jwtUtil.createToken(user.getId(), user.getEmail(), user.getRole());
+    }
+
+    public void updatePassword(UpdatePasswordUserRequestDto updateUserRequestDto) {
+
+        User user = userRepository.findByEmailOrElseThrow(updateUserRequestDto.getEmail());
+
+        String encryptPassword = passwordEncoder.encode(updateUserRequestDto.getNewPassword());
+
+        user.updatePassword(encryptPassword);
     }
 }
 

--- a/src/main/java/com/spotlightspace/core/user/domain/User.java
+++ b/src/main/java/com/spotlightspace/core/user/domain/User.java
@@ -78,9 +78,14 @@ public class User {
         this.nickname = updateUserRequestDto.getNickname();
         this.birth = LocalDate.parse(updateUserRequestDto.getBirth(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         this.phoneNumber = updateUserRequestDto.getPhoneNumber();
-        this.password = encryptPassword;}
+        this.password = encryptPassword;
+    }
 
     public void delete() {
         this.isDeleted = true;
+    }
+
+    public void updatePassword(String encryptPassword) {
+        this.password = encryptPassword;
     }
 }

--- a/src/main/java/com/spotlightspace/core/user/dto/request/UpdatePasswordUserRequestDto.java
+++ b/src/main/java/com/spotlightspace/core/user/dto/request/UpdatePasswordUserRequestDto.java
@@ -1,0 +1,20 @@
+package com.spotlightspace.core.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePasswordUserRequestDto {
+
+    private String email;
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,20}$",
+            message = "비밀번호는 대소문자, 숫자, 특수문자를 포함해 최소 8자, 최대 20자 입력해주세요.")
+    private String newPassword;
+}

--- a/src/test/java/com/spotlightspace/core/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/spotlightspace/core/auth/service/AuthServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 
 import com.spotlightspace.common.entity.TableRole;
 import com.spotlightspace.common.exception.ApplicationException;
@@ -19,6 +20,7 @@ import com.spotlightspace.core.attachment.service.AttachmentService;
 import com.spotlightspace.core.auth.dto.SigninUserRequestDto;
 import com.spotlightspace.core.auth.dto.SignupUserRequestDto;
 import com.spotlightspace.core.user.domain.User;
+import com.spotlightspace.core.user.dto.request.UpdatePasswordUserRequestDto;
 import com.spotlightspace.core.user.repository.UserRepository;
 import java.io.IOException;
 import java.util.Optional;
@@ -32,6 +34,7 @@ import org.mockito.Mock;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(SpringExtension.class)
@@ -168,6 +171,27 @@ class AuthServiceTest {
             // when - then
             assertThrows(ApplicationException.class, () -> authService.signin(signinUserRequestDto));
         }
+    }
 
+    @Nested
+    @DisplayName("유저 비밀번호 테스트")
+    class ChangePasswordTest {
+        @Test
+        @DisplayName("비밀번호 변경 성공")
+        void changePassword_success() {
+            // given
+            String newPassword = "newPassword";
+
+            User user = testUser();
+            ReflectionTestUtils.setField(user,"password", newPassword);
+
+            UpdatePasswordUserRequestDto updateRequestDto = new UpdatePasswordUserRequestDto(user.getEmail(), newPassword);
+
+            given(userRepository.findByEmailOrElseThrow(anyString())).willReturn(user);
+            given(passwordEncoder.matches(anyString(), anyString())).willReturn(true);
+
+            // when - then
+            assertDoesNotThrow(() -> authService.updatePassword(updateRequestDto));
+        }
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- resolved : #26 
## 📝 작업 내용
- 이메일 인증 후 비밀번호 변경 로직을 구현하였습니다!
- 비밀번호 변경은 email과 newpassword를 body로 받습니다!