### PR TITLE
[#38] 리프레시 토큰 구현

### DIFF
--- a/src/main/java/com/spotlightspace/common/constant/JwtConstant.java
+++ b/src/main/java/com/spotlightspace/common/constant/JwtConstant.java
@@ -4,6 +4,7 @@ public abstract class JwtConstant {
 
     public static final String BEARER_PREFIX = "Bearer ";
     public static final long TOKEN_ACCESS_TIME = 60 * 60 * 1000L;
+    public static final long TOKEN_REFRESH_TIME = 60 * 60 * 12 * 1000L;
     public static final String USER_EMAIL = "email";
     public static final String USER_ROLE = "userRole";
 }

--- a/src/main/java/com/spotlightspace/common/exception/ErrorCode.java
+++ b/src/main/java/com/spotlightspace/common/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     INVALID_PASSWORD_OR_EMAIL(NOT_FOUND, "이메일 또는 패스워드가 일치하지 않습니다"),
     EMAIL_DUPLICATED(CONFLICT, "이미 존재하는 이메일입니다."),
     FORBIDDEN_USER(FORBIDDEN, "권한이 없습니다."),
+    INVALID_REFRESH_TOKEN(FORBIDDEN,"리프레시토큰이 없습니다"),
 
     ADMIN_NOT_FOUND(NOT_FOUND, "존재하지 않는 관리자입니다."),
 

--- a/src/main/java/com/spotlightspace/config/JwtSecurityFilter.java
+++ b/src/main/java/com/spotlightspace/config/JwtSecurityFilter.java
@@ -18,14 +18,10 @@ import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import static com.spotlightspace.common.constant.JwtConstant.USER_EMAIL;
-import static com.spotlightspace.common.constant.JwtConstant.USER_ROLE;
 
 @Slf4j(topic = "JwtTokenFilter")
 @RequiredArgsConstructor
@@ -53,11 +49,11 @@ public class JwtSecurityFilter extends OncePerRequestFilter {
         if (Strings.isNotBlank(url) && checkUrlPattern(url)) {
             // 나머지 API 요청은 인증 처리 진행
             // 토큰 확인
-            String tokenValue = request.getHeader(HttpHeaders.AUTHORIZATION);
+            String tokenValue = request.getHeader("AccessToken");
             Cookie[] cookies = request.getCookies();
             if (cookies != null) {
                 for (Cookie cookie : cookies) {
-                    if (cookie.getName().equals(HttpHeaders.AUTHORIZATION)) {
+                    if (cookie.getName().equals("AccessToken")) {
                         tokenValue = URLDecoder.decode(cookie.getValue(), "UTF-8");
                     }
                 }

--- a/src/main/java/com/spotlightspace/config/JwtUtil.java
+++ b/src/main/java/com/spotlightspace/config/JwtUtil.java
@@ -2,6 +2,7 @@ package com.spotlightspace.config;
 
 import static com.spotlightspace.common.constant.JwtConstant.BEARER_PREFIX;
 import static com.spotlightspace.common.constant.JwtConstant.TOKEN_ACCESS_TIME;
+import static com.spotlightspace.common.constant.JwtConstant.TOKEN_REFRESH_TIME;
 import static com.spotlightspace.common.constant.JwtConstant.USER_EMAIL;
 import static com.spotlightspace.common.constant.JwtConstant.USER_ROLE;
 
@@ -15,15 +16,21 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import java.util.Base64;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 @Component
+@RequiredArgsConstructor
 public class JwtUtil {
+
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Value("${jwt.secret.key}")
     private String secretAccessKey;
@@ -37,19 +44,42 @@ public class JwtUtil {
         accessKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secretAccessKey));
     }
 
-    // 토큰 생성
-    public String createToken(Long userId, String email, UserRole userRole) {
+    // 액세스 토큰 생성
+    public String createAccessToken(Long userId, String email, UserRole userRole) {
         Date date = new Date();
+        Date expireDate = new Date(date.getTime() + TOKEN_ACCESS_TIME);
 
         return BEARER_PREFIX +
                 Jwts.builder()
                         .subject(String.valueOf(userId))
                         .claim(USER_EMAIL, email)
                         .claim(USER_ROLE, userRole)
-                        .expiration(new Date(date.getTime() + TOKEN_ACCESS_TIME))
+                        .expiration(expireDate)
                         .issuedAt(date)
                         .signWith(accessKey)
                         .compact();
+    }
+
+    // 리프레시 토큰 생성
+    public String createRefreshToken(Long userId, String email, UserRole userRole) {
+        Date date = new Date();
+        Date expireDate = new Date(date.getTime() + TOKEN_REFRESH_TIME);
+
+        String refreshToken = BEARER_PREFIX +
+                Jwts.builder()
+                        .subject(String.valueOf(userId))
+                        .claim(USER_EMAIL, email)
+                        .claim(USER_ROLE, userRole)
+                        .expiration(expireDate)
+                        .issuedAt(date)
+                        .signWith(accessKey)
+                        .compact();
+
+        String key = "user:id:" + userId;
+        redisTemplate.opsForValue()
+                .set(key, refreshToken, TOKEN_REFRESH_TIME, TimeUnit.MILLISECONDS);
+
+        return refreshToken;
     }
 
     // 토큰 검증
@@ -57,13 +87,17 @@ public class JwtUtil {
         try {
             Jwts.parser().verifyWith(accessKey).build().parseSignedClaims(token).getPayload();
             return true; // 유효한 토큰
-        } catch (SecurityException | MalformedJwtException e) {
+        }
+        catch (SecurityException | MalformedJwtException e) {
             logger.error("잘못된 JWT 서명입니다.");
-        } catch (ExpiredJwtException e) {
+        }
+        catch (ExpiredJwtException e) {
             logger.error("만료된 JWT 토큰입니다.");
-        } catch (UnsupportedJwtException e) {
+        }
+        catch (UnsupportedJwtException e) {
             logger.error("지원되지 않는 JWT 토큰입니다.");
-        } catch (IllegalArgumentException e) {
+        }
+        catch (IllegalArgumentException e) {
             logger.error("JWT 토큰이 잘못되었습니다.");
         }
         return false; // 유효하지 않은 토큰

--- a/src/main/java/com/spotlightspace/config/RedisConfig.java
+++ b/src/main/java/com/spotlightspace/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.spotlightspace.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setEnableTransactionSupport(true);
+        redisTemplate.afterPropertiesSet();
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+        redisConfiguration.setHostName(host);
+        redisConfiguration.setPort(port);
+        return new LettuceConnectionFactory(redisConfiguration);
+    }
+}
+

--- a/src/main/java/com/spotlightspace/core/auth/controller/AuthController.java
+++ b/src/main/java/com/spotlightspace/core/auth/controller/AuthController.java
@@ -1,12 +1,16 @@
 package com.spotlightspace.core.auth.controller;
 
+import static com.spotlightspace.common.constant.JwtConstant.TOKEN_ACCESS_TIME;
+import static com.spotlightspace.common.constant.JwtConstant.TOKEN_REFRESH_TIME;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
+import com.spotlightspace.core.auth.dto.SaveTokenResponseDto;
 import com.spotlightspace.core.auth.dto.SigninUserRequestDto;
 import com.spotlightspace.core.auth.dto.SignupUserRequestDto;
 import com.spotlightspace.core.auth.service.AuthService;
 import com.spotlightspace.core.user.dto.request.UpdatePasswordUserRequestDto;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import java.io.IOException;
@@ -14,6 +18,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,25 +34,38 @@ public class AuthController {
 
     public final AuthService authService;
 
+    /**
+     * 회원가입 로직입니다
+     * @param signupUserRequestDto 이메일, 비밀번호, 닉네임, 권한, 생일을 설정합니다
+     * @param file 유저의 프로필 파일을 업로드하며 필수는 아닙니다
+     * @return
+     * @throws IOException
+     */
     @PostMapping("/auth/signup")
     public ResponseEntity<String> signUp(
             @Valid @RequestPart SignupUserRequestDto signupUserRequestDto,
             @RequestPart(required = false) MultipartFile file) throws IOException {
-        String accessToken = authService.saveUser(signupUserRequestDto, file);
         return ResponseEntity.ok()
-                .header(AUTHORIZATION, accessToken)
                 .build();
     }
 
+    /**
+     * 로그인 로직입니다.
+     * @param signInUserRequestDto 아이디와 비밀번호를 받습니다
+     * @param httpServletResponse 쿠키 저장용입니다
+     * @return 헤더에 엑세스 토큰을 저장합니다
+     * @throws IOException
+     */
     @PostMapping("/auth/signin")
     public ResponseEntity<String> signIn(
             @Valid @RequestBody SigninUserRequestDto signInUserRequestDto,
-            HttpServletResponse response) throws IOException {
-        String accessToken = authService.signin(signInUserRequestDto);
-        setAuthorizationCookie(response, accessToken);
+            HttpServletResponse httpServletResponse) throws IOException {
+        SaveTokenResponseDto tokenDto = authService.signin(signInUserRequestDto);
+        setAccessTokenCookie(httpServletResponse, tokenDto.getAccessToken());
+        setRefreshTokenCookie(httpServletResponse, tokenDto.getRefreshToken());
 
         return ResponseEntity.ok()
-                .header(AUTHORIZATION, accessToken)
+                .header(AUTHORIZATION, tokenDto.getAccessToken())
                 .build();
     }
 
@@ -63,17 +81,45 @@ public class AuthController {
     ) {
         authService.updatePassword(updateUserRequestDto);
         return ResponseEntity.ok().build();
-     }
-  
-    private void setAuthorizationCookie(
+    }
+
+    /**
+     * 리프레시 토큰을 사용하여 토큰을 재발급 받습니다
+     * @param httpServletRequest 쿠키에 있는 리프레시 토큰을 확인합니다
+     * @return 헤더에 accessToken을 발급받습니다.
+     * @throws UnsupportedEncodingException
+     */
+    @GetMapping("/auth/refresh")
+    public ResponseEntity<Void> getAccessToken(
+            HttpServletRequest httpServletRequest) throws UnsupportedEncodingException {
+        String accessToken = authService.getAccessToken(httpServletRequest);
+        return ResponseEntity.ok()
+                .header(AUTHORIZATION, accessToken)
+                .build();
+    }
+
+    private void setAccessTokenCookie(
             HttpServletResponse response,
             String accessToken) throws UnsupportedEncodingException {
         String cookieValue = URLEncoder.encode(accessToken, "utf-8").replaceAll("\\+", "%20");
-        Cookie cookie = new Cookie(AUTHORIZATION, cookieValue);
+        Cookie cookie = new Cookie("AccessToken", cookieValue);
         cookie.setPath("/");
         cookie.setSecure(true);
         cookie.setHttpOnly(true);
-        cookie.setMaxAge(60 * 25);
+        cookie.setMaxAge((int) TOKEN_ACCESS_TIME);
         response.addCookie(cookie);
     }
+
+    private void setRefreshTokenCookie(
+            HttpServletResponse response,
+            String accessToken) throws UnsupportedEncodingException {
+        String cookieValue = URLEncoder.encode(accessToken, "utf-8").replaceAll("\\+", "%20");
+        Cookie cookie = new Cookie("RefreshToken", cookieValue);
+        cookie.setPath("/");
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge((int) TOKEN_REFRESH_TIME);
+        response.addCookie(cookie);
+    }
+
 }

--- a/src/main/java/com/spotlightspace/core/auth/dto/SaveTokenResponseDto.java
+++ b/src/main/java/com/spotlightspace/core/auth/dto/SaveTokenResponseDto.java
@@ -1,0 +1,19 @@
+package com.spotlightspace.core.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SaveTokenResponseDto {
+
+    private String accessToken;
+    private String refreshToken;
+
+    private SaveTokenResponseDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public static SaveTokenResponseDto of(String accessToken, String refreshToken) {
+        return new SaveTokenResponseDto(accessToken, refreshToken);
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- resolved : #38 
## 📝 작업 내용
- 리프레시 토큰을 구현했습니다
- 회원가입시 리프레시토큰은 쿠키로, 엑세스토큰은 헤더로 전송됩니다
- 엑세스토큰이 만료가된다면 리프레시토큰 api를 통해 재발급 가능합니다.
- 리프레시 토큰 api는 쿠키에 있는 리프레시토큰의 키를 redis에서 조회해, 현재 쿠키의 jwt토큰과 redis에 저장된 jwt토큰이 일치한다면 액세스토큰을 재발급해줍니다.