### PR TITLE
[#23] 결제 기능 구현 - 4차

### DIFF
--- a/src/main/java/com/spotlightspace/common/exception/ErrorCode.java
+++ b/src/main/java/com/spotlightspace/common/exception/ErrorCode.java
@@ -35,10 +35,12 @@ public enum ErrorCode {
 
     POINT_HISTORY_NOT_FOUND(NOT_FOUND, "존재하지 않는 포인트 기록입니다."),
 
+    EVENT_TICKET_OUT_OF_STOCK(BAD_REQUEST, "이벤트 티켓 재고가 없습니다"),
+    EVENT_TICKET_STOCK_NOT_FOUND(NOT_FOUND, "존재하지 않는 이벤트 티켓 재고입니다."),
+
     COUPON_ALREADY_USED(BAD_REQUEST, "이미 사용된 쿠폰입니다."),
     COUPON_NOT_FOUND(NOT_FOUND, "존재하지 않는 쿠폰입니다."),
 
-    EVENT_PARTICIPANT_LIMIT_EXCEED(BAD_REQUEST, "이벤트 참석자 수를 초과하였습니다."),
     INVALID_PAYMENT_STATUS(BAD_REQUEST, "유효하지 않은 결제 상태입니다."),
     NOT_IN_EVENT_RECRUITMENT_PERIOD(BAD_REQUEST, "이벤트 모집 기간이 아닙니다."),
     TID_NOT_FOUND(NOT_FOUND, "결제 고유 번호가 존재하지 않습니다."),

--- a/src/main/java/com/spotlightspace/core/event/service/EventService.java
+++ b/src/main/java/com/spotlightspace/core/event/service/EventService.java
@@ -7,7 +7,9 @@ import com.spotlightspace.core.attachment.service.AttachmentService;
 import com.spotlightspace.core.event.domain.Event;
 import com.spotlightspace.core.event.dto.*;
 import com.spotlightspace.core.event.repository.EventRepository;
+import com.spotlightspace.core.eventticketstock.domain.EventTicketStock;
 import com.spotlightspace.core.ticket.repository.TicketRepository;
+import com.spotlightspace.core.eventticketstock.repository.EventTicketStockRepository;
 import com.spotlightspace.core.user.domain.User;
 import com.spotlightspace.core.user.domain.UserRole;
 import com.spotlightspace.core.user.repository.UserRepository;
@@ -20,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.spotlightspace.common.exception.ErrorCode.*;
@@ -35,6 +36,7 @@ public class EventService {
     private final UserRepository userRepository;
     private final AttachmentService attachmentService;
     private final TicketRepository ticketRepository;
+    private final EventTicketStockRepository eventTicketStockRepository;
 
     @Transactional
     public CreateEventResponseDto createEvent(CreateEventRequestDto requestDto, AuthUser authUser, List<MultipartFile> files) throws IOException {
@@ -47,6 +49,9 @@ public class EventService {
         if (files != null && !files.isEmpty()) {
             attachmentService.addAttachmentList(files, event.getId(), TableRole.EVENT);
         }
+
+        eventTicketStockRepository.save(EventTicketStock.create(event));
+
         return CreateEventResponseDto.from(event);
     }
 

--- a/src/main/java/com/spotlightspace/core/eventticketstock/domain/EventTicketStock.java
+++ b/src/main/java/com/spotlightspace/core/eventticketstock/domain/EventTicketStock.java
@@ -1,0 +1,53 @@
+package com.spotlightspace.core.eventticketstock.domain;
+
+import com.spotlightspace.core.event.domain.Event;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "event_ticket_stocks")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventTicketStock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    private int stock;
+
+    private EventTicketStock(Event event, int stock) {
+        this.event = event;
+        this.stock = stock;
+    }
+
+    public static EventTicketStock create(Event event) {
+        return new EventTicketStock(event, event.getMaxPeople());
+    }
+
+    public boolean isOutOfStock() {
+        return stock == 0;
+    }
+
+    public void decreaseStock() {
+        this.stock--;
+    }
+
+    public void increaseStock() {
+        this.stock++;
+    }
+}

--- a/src/main/java/com/spotlightspace/core/eventticketstock/repository/EventTicketStockRepository.java
+++ b/src/main/java/com/spotlightspace/core/eventticketstock/repository/EventTicketStockRepository.java
@@ -1,0 +1,18 @@
+package com.spotlightspace.core.eventticketstock.repository;
+
+import static com.spotlightspace.common.exception.ErrorCode.EVENT_TICKET_STOCK_NOT_FOUND;
+
+import com.spotlightspace.common.exception.ApplicationException;
+import com.spotlightspace.core.event.domain.Event;
+import com.spotlightspace.core.eventticketstock.domain.EventTicketStock;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventTicketStockRepository extends JpaRepository<EventTicketStock, Long> {
+
+    Optional<EventTicketStock> findByEvent(Event event);
+
+    default EventTicketStock findByEventOrElseThrow(Event event) {
+        return findByEvent(event).orElseThrow(() -> new ApplicationException(EVENT_TICKET_STOCK_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/spotlightspace/core/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/spotlightspace/core/payment/repository/PaymentRepository.java
@@ -3,9 +3,7 @@ package com.spotlightspace.core.payment.repository;
 import static com.spotlightspace.common.exception.ErrorCode.TID_NOT_FOUND;
 
 import com.spotlightspace.common.exception.ApplicationException;
-import com.spotlightspace.core.event.domain.Event;
 import com.spotlightspace.core.payment.domain.Payment;
-import com.spotlightspace.core.payment.domain.PaymentStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,8 +13,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long>, Payment
 
     @Query("select p from Payment p left join fetch p.userCoupon where p.tid = :tid")
     Optional<Payment> findByTid(@Param("tid") String tid);
-
-    long countByEventAndStatus(Event event, PaymentStatus status);
 
     default Payment findByTidOrElseThrow(String tid) {
         return findByTid(tid).orElseThrow(() -> new ApplicationException(TID_NOT_FOUND));


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #23 
## 📝 작업 내용
- 이벤트 티켓 재고 관리를 위한 테이블 추가 및 관련 코드 변경
## 💬 추가 설명
- 여러 회차에 나누어 개발할 예정입니다.
  - #33 
  - #44 
  - #54  
  - 4차에는 재고 관리를 위해 테이블을 추가하였으며 이로 인한 코드 변경이 생겼습니다.
      - 이벤트 관련하여 코드 변경이 생겼습니다.
  - 이후 차시에는 결제 이력 관리, 동시성, 실패 시 재시도, 테스트 코드 등을 진행할 예정입니다.