### PR TITLE
[#80] 결제에 대해 락 적용

### DIFF
--- a/src/main/java/com/spotlightspace/core/eventticketstock/repository/EventTicketStockRepository.java
+++ b/src/main/java/com/spotlightspace/core/eventticketstock/repository/EventTicketStockRepository.java
@@ -5,14 +5,26 @@ import static com.spotlightspace.common.exception.ErrorCode.EVENT_TICKET_STOCK_N
 import com.spotlightspace.common.exception.ApplicationException;
 import com.spotlightspace.core.event.domain.Event;
 import com.spotlightspace.core.eventticketstock.domain.EventTicketStock;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface EventTicketStockRepository extends JpaRepository<EventTicketStock, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select e from EventTicketStock e where e.event.id = :eventId")
+    Optional<EventTicketStock> findByEventIdWithPessimisticLock(long eventId);
 
     Optional<EventTicketStock> findByEvent(Event event);
 
     default EventTicketStock findByEventOrElseThrow(Event event) {
         return findByEvent(event).orElseThrow(() -> new ApplicationException(EVENT_TICKET_STOCK_NOT_FOUND));
+    }
+
+    default EventTicketStock findByEventIdWithPessimisticLockOrElseThrow(long eventId) {
+        return findByEventIdWithPessimisticLock(eventId)
+                .orElseThrow(() -> new ApplicationException(EVENT_TICKET_STOCK_NOT_FOUND));
     }
 }

--- a/src/main/java/com/spotlightspace/core/payment/service/PaymentService.java
+++ b/src/main/java/com/spotlightspace/core/payment/service/PaymentService.java
@@ -62,7 +62,8 @@ public class PaymentService {
     public ReadyPaymentResponseDto readyPayment(long userId, long eventId, Long couponId, Integer pointAmount) {
         User user = userRepository.findByIdOrElseThrow(userId);
         Event event = eventRepository.findByIdOrElseThrow(eventId);
-        EventTicketStock eventTicketStock = eventTicketStockRepository.findByEventOrElseThrow(event);
+        EventTicketStock eventTicketStock = eventTicketStockRepository
+                .findByEventIdWithPessimisticLockOrElseThrow(event.getId());
 
         validateRecruitmentPeriod(event);
         validateEventTicketStock(eventTicketStock);

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -4,6 +4,8 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 50
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/test/java/com/spotlightspace/core/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/spotlightspace/core/payment/service/PaymentServiceTest.java
@@ -1,0 +1,123 @@
+package com.spotlightspace.core.payment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.anyInt;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.spotlightspace.core.data.UserTestData;
+import com.spotlightspace.core.event.domain.Event;
+import com.spotlightspace.core.event.domain.EventCategory;
+import com.spotlightspace.core.event.dto.CreateEventRequestDto;
+import com.spotlightspace.core.event.repository.EventRepository;
+import com.spotlightspace.core.eventticketstock.domain.EventTicketStock;
+import com.spotlightspace.core.eventticketstock.repository.EventTicketStockRepository;
+import com.spotlightspace.core.payment.domain.Payment;
+import com.spotlightspace.core.payment.dto.response.ReadyPaymentResponseDto;
+import com.spotlightspace.core.payment.repository.PaymentRepository;
+import com.spotlightspace.core.user.domain.User;
+import com.spotlightspace.core.user.repository.UserRepository;
+import com.spotlightspace.integration.kakaopay.KakaopayApi;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@Slf4j
+@SpringBootTest
+class PaymentServiceTest {
+
+    @Autowired
+    PaymentService paymentService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    EventRepository eventRepository;
+
+    @Autowired
+    EventTicketStockRepository eventTicketStockRepository;
+
+    @Autowired
+    PaymentRepository paymentRepository;
+
+    @MockBean
+    KakaopayApi kakaopayApi;
+
+    @AfterEach
+    void tearDown() {
+        paymentRepository.deleteAllInBatch();
+        eventTicketStockRepository.deleteAllInBatch();
+        eventRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("결제 동시성 테스트 - Pessimistic Lock")
+    void pessimisticLock() throws InterruptedException {
+        // given
+        User user = userRepository.save(UserTestData.testUser());
+        CreateEventRequestDto createEventRequestDto = getCreateEventRequestDtoWithMaxPeople(10);
+        Event event = eventRepository.save(Event.of(createEventRequestDto, user));
+        EventTicketStock eventTicketStock = eventTicketStockRepository.save(EventTicketStock.create(event));
+
+        given(kakaopayApi.readyPayment(anyString(), anyLong(), anyLong(), anyString(), anyLong(), anyInt()))
+                .willReturn(createReadyPaymentResponseDto());
+
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    paymentService.readyPayment(user.getId(), event.getId(), null, null);
+                } catch (Exception e) {
+                    System.err.println("결제 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        // then
+        List<Payment> payments = paymentRepository.findAll();
+        EventTicketStock foundEventTicketStock = eventTicketStockRepository.findById(eventTicketStock.getId()).get();
+        assertThat(payments).hasSize(10);
+        assertThat(foundEventTicketStock.getStock()).isEqualTo(0);
+    }
+
+    ReadyPaymentResponseDto createReadyPaymentResponseDto() {
+        return new ReadyPaymentResponseDto(
+                "tid",
+                "url",
+                "url",
+                "url",
+                "url",
+                "url",
+                LocalDateTime.now()
+        );
+    }
+
+    CreateEventRequestDto getCreateEventRequestDtoWithMaxPeople(int maxPeople) {
+        return new CreateEventRequestDto("title", "content", "location",
+                LocalDateTime.of(2024, 12, 12, 12, 0),
+                LocalDateTime.of(2024, 12, 12, 14, 0), maxPeople, 10_000,
+                EventCategory.ART, LocalDateTime.of(2024, 10, 10, 0, 0),
+                LocalDateTime.of(2024, 12, 10, 0, 0));
+    }
+
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- resolved: #80 
## 📝 작업 내용
- optimistic lock, pessimistic lock, mysql user-level-lock, redisson, lettuce를 각각 실행해본 뒤 pessimistic lock 적용
    - 결정 기준은 테스트 코드를 통한 실행속도 기준으로 결정하였습니다.
    - pessimistic lock 사용으로 인한 db 부하 문제와 connection pool size 문제는 추후 부하테스트를 통해 논의 예정입니다.