### PR TITLE
[#29]어드민 권한 삭제 기능 구현

### DIFF
--- a/src/main/java/com/spotlightspace/core/admin/controller/AdminEventController.java
+++ b/src/main/java/com/spotlightspace/core/admin/controller/AdminEventController.java
@@ -7,10 +7,7 @@ import com.spotlightspace.core.admin.service.AdminEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.spotlightspace.common.exception.ErrorCode.NO_RESULTS_FOUND;
 
@@ -48,4 +45,10 @@ public class AdminEventController {
         }
         return ResponseEntity.ok(events);
     }
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<Void> deleteEvent(@PathVariable Long id) {
+        adminEventService.deleteEvent(id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/spotlightspace/core/admin/controller/AdminReviewController.java
+++ b/src/main/java/com/spotlightspace/core/admin/controller/AdminReviewController.java
@@ -2,16 +2,12 @@ package com.spotlightspace.core.admin.controller;
 
 
 import com.spotlightspace.common.exception.ApplicationException;
-import com.spotlightspace.common.exception.ErrorCode;
 import com.spotlightspace.core.admin.dto.responsedto.AdminReviewResponseDto;
 import com.spotlightspace.core.admin.service.AdminReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.spotlightspace.common.exception.ErrorCode.NO_RESULTS_FOUND;
 
@@ -46,4 +42,11 @@ public class AdminReviewController {
         }
         return ResponseEntity.ok(reviews);
     }
+
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<Void> deleteReview(@PathVariable Long id) {
+        adminReviewService.deleteReview(id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/spotlightspace/core/admin/controller/AdminUserController.java
+++ b/src/main/java/com/spotlightspace/core/admin/controller/AdminUserController.java
@@ -1,16 +1,12 @@
 package com.spotlightspace.core.admin.controller;
 
 import com.spotlightspace.common.exception.ApplicationException;
-import com.spotlightspace.common.exception.ErrorCode;
 import com.spotlightspace.core.admin.dto.responsedto.AdminUserResponseDto;
 import com.spotlightspace.core.admin.service.AdminUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.spotlightspace.common.exception.ErrorCode.NO_RESULTS_FOUND;
 
@@ -44,4 +40,10 @@ public class AdminUserController {
         }
         return ResponseEntity.ok(users);
     }
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        adminUserService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/spotlightspace/core/admin/dto/responsedto/AdminReviewResponseDto.java
+++ b/src/main/java/com/spotlightspace/core/admin/dto/responsedto/AdminReviewResponseDto.java
@@ -20,4 +20,5 @@ public class AdminReviewResponseDto {
     public static AdminReviewResponseDto of(Long id, String eventTitle, String userNickname, String contents, Integer rating, Boolean isDeleted) {
         return new AdminReviewResponseDto(id, eventTitle, userNickname, contents, rating, isDeleted);
     }
+
 }

--- a/src/main/java/com/spotlightspace/core/admin/repository/AdminQueryRepository.java
+++ b/src/main/java/com/spotlightspace/core/admin/repository/AdminQueryRepository.java
@@ -3,12 +3,20 @@ package com.spotlightspace.core.admin.repository;
 import com.spotlightspace.core.admin.dto.responsedto.AdminEventResponseDto;
 import com.spotlightspace.core.admin.dto.responsedto.AdminReviewResponseDto;
 import com.spotlightspace.core.admin.dto.responsedto.AdminUserResponseDto;
+import com.spotlightspace.core.event.domain.Event;
+import com.spotlightspace.core.review.domain.Review;
+import com.spotlightspace.core.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
 
 
 public interface AdminQueryRepository {
     Page<AdminUserResponseDto> getAdminUsers(String keyword, Pageable pageable);
     Page<AdminEventResponseDto> getAdminEvents(String keyword, Pageable pageable);
     Page<AdminReviewResponseDto> getAdminReviews(String keyword, Pageable pageable);
+    Optional<User> findUserById(Long id);
+    Optional<Event> findEventById(Long id);
+    Optional<Review> findReviewById(Long id);
 }

--- a/src/main/java/com/spotlightspace/core/admin/repository/AdminQueryRepositoryImpl.java
+++ b/src/main/java/com/spotlightspace/core/admin/repository/AdminQueryRepositoryImpl.java
@@ -11,6 +11,12 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.spotlightspace.core.admin.dto.responsedto.AdminEventResponseDto;
 import com.spotlightspace.core.admin.dto.responsedto.AdminReviewResponseDto;
 import com.spotlightspace.core.admin.dto.responsedto.AdminUserResponseDto;
+import com.spotlightspace.core.event.domain.Event;
+import com.spotlightspace.core.event.domain.QEvent;
+import com.spotlightspace.core.review.domain.QReview;
+import com.spotlightspace.core.review.domain.Review;
+import com.spotlightspace.core.user.domain.QUser;
+import com.spotlightspace.core.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -19,6 +25,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.spotlightspace.core.event.domain.QEvent.event;
@@ -194,6 +201,33 @@ public class AdminQueryRepositoryImpl implements AdminQueryRepository {
         }
         return review.contents.startsWith(keyword)
                 .or(review.user.nickname.startsWith(keyword));
+    }
+
+    @Override
+    public Optional<User> findUserById(Long id) {
+        User user = queryFactory
+                .selectFrom(QUser.user)
+                .where(QUser.user.id.eq(id))
+                .fetchOne();
+        return Optional.ofNullable(user);
+    }
+
+    @Override
+    public Optional<Event> findEventById(Long id) {
+        Event event = queryFactory
+                .selectFrom(QEvent.event)
+                .where(QEvent.event.id.eq(id))
+                .fetchOne();
+        return Optional.ofNullable(event);
+    }
+
+    @Override
+    public Optional<Review> findReviewById(Long id) {
+        Review review = queryFactory
+                .selectFrom(QReview.review)
+                .where(QReview.review.id.eq(id))
+                .fetchOne();
+        return Optional.ofNullable(review);
     }
 
 }

--- a/src/main/java/com/spotlightspace/core/admin/service/AdminEventService.java
+++ b/src/main/java/com/spotlightspace/core/admin/service/AdminEventService.java
@@ -1,7 +1,9 @@
 package com.spotlightspace.core.admin.service;
 
+import com.spotlightspace.common.exception.ApplicationException;
 import com.spotlightspace.core.admin.dto.responsedto.AdminEventResponseDto;
 import com.spotlightspace.core.admin.repository.AdminQueryRepository;
+import com.spotlightspace.core.event.domain.Event;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -10,13 +12,16 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.spotlightspace.common.exception.ErrorCode.EVENT_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+
 public class AdminEventService {
 
     private final AdminQueryRepository adminRepository;
 
+    @Transactional(readOnly = true)
     public Page<AdminEventResponseDto> getAdminEvents(int page, int size, String keyword, String sortField, String sortOrder) {
         Sort sort = Sort.by(sortField);
         if ("desc".equalsIgnoreCase(sortOrder)) {
@@ -30,4 +35,11 @@ public class AdminEventService {
         // AdminRepository의 QueryDSL 메서드를 통해 검색 수행 (검색어 추가)
         return adminRepository.getAdminEvents(keyword, pageable);
     }
+    @Transactional
+    public void deleteEvent(Long id) {
+        Event event = adminRepository.findEventById(id)
+                .orElseThrow(() -> new ApplicationException(EVENT_NOT_FOUND));
+        event.deleteEvent();
+    }
+
 }

--- a/src/main/java/com/spotlightspace/core/admin/service/AdminReviewService.java
+++ b/src/main/java/com/spotlightspace/core/admin/service/AdminReviewService.java
@@ -3,8 +3,10 @@ package com.spotlightspace.core.admin.service;
 
 
 
+import com.spotlightspace.common.exception.ApplicationException;
 import com.spotlightspace.core.admin.dto.responsedto.AdminReviewResponseDto;
 import com.spotlightspace.core.admin.repository.AdminQueryRepository;
+import com.spotlightspace.core.review.domain.Review;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -13,13 +15,16 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.spotlightspace.common.exception.ErrorCode.REVIEW_NOT_FOUND;
+
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+
 public class AdminReviewService {
 
     private final AdminQueryRepository adminRepository;
 
+    @Transactional(readOnly = true)
     public Page<AdminReviewResponseDto> getAdminReviews(int page, int size, String keyword, String sortField, String sortOrder) {
         Sort sort = Sort.by(sortField);
         if ("desc".equalsIgnoreCase(sortOrder)) {
@@ -33,4 +38,12 @@ public class AdminReviewService {
         // AdminRepository의 QueryDSL 메서드를 통해 검색 수행 (검색어 추가)
         return adminRepository.getAdminReviews(keyword, pageable);
     }
+
+    @Transactional
+    public void deleteReview(Long id) {
+        Review review = adminRepository.findReviewById(id)
+                .orElseThrow(() -> new ApplicationException(REVIEW_NOT_FOUND));
+        review.changeIsDeleted();
+    }
+
 }

--- a/src/main/java/com/spotlightspace/core/admin/service/AdminUserService.java
+++ b/src/main/java/com/spotlightspace/core/admin/service/AdminUserService.java
@@ -1,7 +1,9 @@
 package com.spotlightspace.core.admin.service;
 
+import com.spotlightspace.common.exception.ApplicationException;
 import com.spotlightspace.core.admin.dto.responsedto.AdminUserResponseDto;
 import com.spotlightspace.core.admin.repository.AdminQueryRepository;
+import com.spotlightspace.core.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -10,14 +12,17 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.spotlightspace.common.exception.ErrorCode.USER_NOT_FOUND;
+
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+
 public class AdminUserService {
 
     private final AdminQueryRepository adminRepository;
 
+    @Transactional(readOnly = true)
     public Page<AdminUserResponseDto> getAdminUsers(int page, int size, String keyword, String sortField, String sortOrder) {
         Sort sort = Sort.by(sortField);
         if ("desc".equalsIgnoreCase(sortOrder)) {
@@ -29,4 +34,12 @@ public class AdminUserService {
         Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, sort);
         return adminRepository.getAdminUsers(keyword, pageable);
     }
+
+    @Transactional
+    public void deleteUser(Long id) {
+        User user = adminRepository.findUserById(id)
+                .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
+        user.delete();
+    }
+
 }

--- a/src/test/java/com/spotlightspace/core/admin/service/AdminEventServiceTest.java
+++ b/src/test/java/com/spotlightspace/core/admin/service/AdminEventServiceTest.java
@@ -1,7 +1,9 @@
 package com.spotlightspace.core.admin.service;
 
+import com.spotlightspace.common.exception.ApplicationException;
 import com.spotlightspace.core.admin.dto.responsedto.AdminEventResponseDto;
 import com.spotlightspace.core.admin.repository.AdminQueryRepository;
+import com.spotlightspace.core.event.domain.Event;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -13,10 +15,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
 import java.util.Collections;
+import java.util.Optional;
 
+import static com.spotlightspace.common.exception.ErrorCode.EVENT_NOT_FOUND;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class AdminEventServiceTest {
 
@@ -69,4 +74,29 @@ class AdminEventServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getContent()).isEmpty();
     }
+
+    @Test
+    void testDeleteEvent_Success() {
+        // given
+        Event event = mock(Event.class);
+        when(adminRepository.findEventById(anyLong())).thenReturn(Optional.of(event));
+
+        // when
+        adminEventService.deleteEvent(1L);
+
+        // then
+        verify(event, times(1)).deleteEvent();
+    }
+
+    @Test
+    void testDeleteEvent_EventNotFound() {
+        // given
+        when(adminRepository.findEventById(anyLong())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminEventService.deleteEvent(1L))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(EVENT_NOT_FOUND.getMessage());
+    }
+
 }

--- a/src/test/java/com/spotlightspace/core/admin/service/AdminReviewServiceTest.java
+++ b/src/test/java/com/spotlightspace/core/admin/service/AdminReviewServiceTest.java
@@ -1,8 +1,10 @@
 package com.spotlightspace.core.admin.service;
 
 
+import com.spotlightspace.common.exception.ApplicationException;
 import com.spotlightspace.core.admin.dto.responsedto.AdminReviewResponseDto;
 import com.spotlightspace.core.admin.repository.AdminQueryRepository;
+import com.spotlightspace.core.review.domain.Review;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -14,10 +16,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
 import java.util.Collections;
+import java.util.Optional;
 
+import static com.spotlightspace.common.exception.ErrorCode.REVIEW_NOT_FOUND;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class AdminReviewServiceTest {
 
@@ -69,4 +74,31 @@ class AdminReviewServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getContent()).isEmpty();
     }
+
+
+
+    @Test
+    void testDeleteReview_Success() {
+        // given
+        Review review = mock(Review.class);
+        when(adminRepository.findReviewById(anyLong())).thenReturn(Optional.of(review));
+
+        // when
+        adminReviewService.deleteReview(1L);
+
+        // then
+        verify(review, times(1)).changeIsDeleted();
+    }
+
+    @Test
+    void testDeleteReview_ReviewNotFound() {
+        // given
+        when(adminRepository.findReviewById(anyLong())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminReviewService.deleteReview(1L))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(REVIEW_NOT_FOUND.getMessage());
+    }
+
 }

--- a/src/test/java/com/spotlightspace/core/admin/service/AdminUserServiceTest.java
+++ b/src/test/java/com/spotlightspace/core/admin/service/AdminUserServiceTest.java
@@ -1,7 +1,9 @@
 package com.spotlightspace.core.admin.service;
 
+import com.spotlightspace.common.exception.ApplicationException;
 import com.spotlightspace.core.admin.dto.responsedto.AdminUserResponseDto;
 import com.spotlightspace.core.admin.repository.AdminQueryRepository;
+import com.spotlightspace.core.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -13,10 +15,13 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
 import java.util.Collections;
+import java.util.Optional;
 
+import static com.spotlightspace.common.exception.ErrorCode.USER_NOT_FOUND;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class AdminUserServiceTest {
 
@@ -65,5 +70,30 @@ class AdminUserServiceTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void testDeleteUser_Success() {
+        // given
+        User user = mock(User.class);
+        when(adminRepository.findUserById(anyLong())).thenReturn(Optional.of(user));
+
+        // when
+        adminUserService.deleteUser(1L);
+
+        // then
+        verify(user, times(1)).delete();
+    }
+
+
+    @Test
+    void testDeleteUser_UserNotFound() {
+        // given
+        when(adminRepository.findUserById(anyLong())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> adminUserService.deleteUser(1L))
+                .isInstanceOf(ApplicationException.class)
+                .hasMessage(USER_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈

- resolved : #29
## 📝 작업 내용
어드민 권한 삭제 기능 구현
이벤트, 리뷰, 유저의 아이디를 입력 받아서 삭제하는 기능 구현