### PR TITLE
[#91] 결제 실패 시 스케줄러를 이용해 fail 상태로 변경 기능 구현

### DIFF
--- a/src/main/java/com/spotlightspace/config/SchedulerConfig.java
+++ b/src/main/java/com/spotlightspace/config/SchedulerConfig.java
@@ -1,0 +1,10 @@
+package com.spotlightspace.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+}

--- a/src/main/java/com/spotlightspace/core/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/spotlightspace/core/payment/repository/PaymentRepository.java
@@ -6,6 +6,7 @@ import com.spotlightspace.common.exception.ApplicationException;
 import com.spotlightspace.core.event.domain.Event;
 import com.spotlightspace.core.payment.domain.Payment;
 import com.spotlightspace.core.payment.domain.PaymentStatus;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,4 +24,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long>, Payment
 
     @Query("select p from Payment p where p.event = :event and p.status = :status")
     List<Payment> findPaymentsByEventAndStatus(@Param("event") Event event, @Param("status") PaymentStatus status);
+
+    List<Payment> findAllByStatusAndUpdateAtBefore(PaymentStatus paymentStatus, LocalDateTime failDateTime);
 }

--- a/src/main/java/com/spotlightspace/core/payment/scheduler/PaymentScheduler.java
+++ b/src/main/java/com/spotlightspace/core/payment/scheduler/PaymentScheduler.java
@@ -1,0 +1,28 @@
+package com.spotlightspace.core.payment.scheduler;
+
+import static com.spotlightspace.core.payment.domain.PaymentStatus.READY;
+
+import com.spotlightspace.core.payment.domain.Payment;
+import com.spotlightspace.core.payment.repository.PaymentRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentScheduler {
+
+    private static final int ONE_MINUTE = 60_000;
+    private static final long FIFTEEN_MINUTE = 15L;
+
+    private final PaymentRepository paymentRepository;
+
+    @Transactional
+    @Scheduled(fixedDelay = ONE_MINUTE)
+    public void failPayment() {
+        paymentRepository.findAllByStatusAndUpdateAtBefore(READY, LocalDateTime.now().minusMinutes(FIFTEEN_MINUTE))
+                .forEach(Payment::fail);
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- resolved: #91 
## 📝 작업 내용
- 스케줄러를 이용하여 1분마다 DB를 조회하여 15분이 지났지만 상태가 READY인 결제를 FAILED 상태로 변경하도록 구현했습니다.