### PR TITLE
[#99] 결제 중 spotlight 서버 문제 시 재시도 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,9 @@ dependencies {
     implementation("com.slack.api:bolt-servlet:1.44.1")
     implementation("com.slack.api:bolt-jetty:1.44.1")
     implementation("org.slf4j:slf4j-simple:1.7.36")
+
+    // spring retry
+    implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.10'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/spotlightspace/config/SpringRetryConfig.java
+++ b/src/main/java/com/spotlightspace/config/SpringRetryConfig.java
@@ -1,0 +1,10 @@
+package com.spotlightspace.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class SpringRetryConfig {
+
+}

--- a/src/main/java/com/spotlightspace/core/payment/controller/PaymentController.java
+++ b/src/main/java/com/spotlightspace/core/payment/controller/PaymentController.java
@@ -75,7 +75,6 @@ public class PaymentController {
                 paymentDto.getEventId(),
                 paymentDto.getDiscountedAmount()
         );
-
         paymentService.readyPayment(paymentDto.getPaymentId(), readyPaymentResponseDto.getTid());
 
         return ResponseEntity.ok(readyPaymentResponseDto);
@@ -95,7 +94,6 @@ public class PaymentController {
     ) {
         PaymentDto paymentDto = paymentService.getPayment((long) session.getAttribute(PAYMENT_ID));
 
-        paymentService.approvePayment(paymentDto.getPaymentId());
         ApprovePaymentResponseDto responseDto = kakaopayApi.approvePayment(
                 pgToken,
                 paymentDto.getTid(),
@@ -103,6 +101,7 @@ public class PaymentController {
                 paymentDto.getPaymentId(),
                 paymentDto.getUserId()
         );
+        paymentService.approvePayment(paymentDto.getPaymentId());
 
         return ResponseEntity.ok(responseDto);
     }
@@ -117,13 +116,13 @@ public class PaymentController {
     public ResponseEntity<CancelPaymentResponseDto> cancelPayment(@RequestBody CancelPaymentRequestDto requestDto) {
         PaymentDto paymentDto = paymentService.getPayment(requestDto.getPaymentId());
 
-        paymentService.cancelPayment(paymentDto.getPaymentId());
         CancelPaymentResponseDto responseDto = kakaopayApi.cancelPayment(
                 paymentDto.getCid(),
                 paymentDto.getTid(),
                 paymentDto.getDiscountedAmount(),
                 0
         );
+        paymentService.cancelPayment(paymentDto.getPaymentId());
 
         return ResponseEntity.ok(responseDto);
     }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- resolved: #99 
## 📝 작업 내용
- spring retry를 사용하여 재시도 로직을 구현하였습니다.
- 3회 재시도 이후에도 실패한다면 슬랙 알림을 보내도록 구현하였습니다.