### PR TITLE
[#103] 결제 실패 시 재고 원상복구 기능 구현

### DIFF
--- a/src/main/java/com/spotlightspace/core/eventticketstock/domain/EventTicketStock.java
+++ b/src/main/java/com/spotlightspace/core/eventticketstock/domain/EventTicketStock.java
@@ -47,6 +47,10 @@ public class EventTicketStock {
         this.stock--;
     }
 
+    public void decreaseStock(long count) {
+        this.stock -= count;
+    }
+
     public void increaseStock() {
         this.stock++;
     }

--- a/src/main/java/com/spotlightspace/core/eventticketstock/repository/EventTicketStockRepository.java
+++ b/src/main/java/com/spotlightspace/core/eventticketstock/repository/EventTicketStockRepository.java
@@ -6,7 +6,9 @@ import com.spotlightspace.common.exception.ApplicationException;
 import com.spotlightspace.core.event.domain.Event;
 import com.spotlightspace.core.eventticketstock.domain.EventTicketStock;
 import jakarta.persistence.LockModeType;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -17,7 +19,12 @@ public interface EventTicketStockRepository extends JpaRepository<EventTicketSto
     @Query("select e from EventTicketStock e where e.event.id = :eventId")
     Optional<EventTicketStock> findByEventIdWithPessimisticLock(long eventId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<EventTicketStock> findByEvent(Event event);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select e from EventTicketStock e where e.event in :events")
+    List<EventTicketStock> findEventTicketStocksByEventIn(Set<Event> events);
 
     default EventTicketStock findByEventOrElseThrow(Event event) {
         return findByEvent(event).orElseThrow(() -> new ApplicationException(EVENT_TICKET_STOCK_NOT_FOUND));

--- a/src/main/java/com/spotlightspace/core/payment/scheduler/PaymentScheduler.java
+++ b/src/main/java/com/spotlightspace/core/payment/scheduler/PaymentScheduler.java
@@ -2,9 +2,14 @@ package com.spotlightspace.core.payment.scheduler;
 
 import static com.spotlightspace.core.payment.domain.PaymentStatus.READY;
 
+import com.spotlightspace.core.event.domain.Event;
+import com.spotlightspace.core.eventticketstock.repository.EventTicketStockRepository;
 import com.spotlightspace.core.payment.domain.Payment;
 import com.spotlightspace.core.payment.repository.PaymentRepository;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -18,11 +23,31 @@ public class PaymentScheduler {
     private static final long FIFTEEN_MINUTE = 15L;
 
     private final PaymentRepository paymentRepository;
+    private final EventTicketStockRepository eventTicketStockRepository;
 
     @Transactional
     @Scheduled(fixedDelay = ONE_MINUTE)
     public void failPayment() {
-        paymentRepository.findAllByStatusAndUpdateAtBefore(READY, LocalDateTime.now().minusMinutes(FIFTEEN_MINUTE))
-                .forEach(Payment::fail);
+        List<Payment> payments = paymentRepository.findAllByStatusAndUpdateAtBefore(
+                READY,
+                LocalDateTime.now().minusMinutes(FIFTEEN_MINUTE)
+        );
+        if (payments.isEmpty()) {
+            return;
+        }
+
+        Map<Event, Long> eventPaymentCountMap = new HashMap<>();
+        for (Payment payment : payments) {
+            payment.fail();
+            eventPaymentCountMap.put(
+                    payment.getEvent(),
+                    eventPaymentCountMap.getOrDefault(payment.getEvent(), 0L) + 1
+            );
+        }
+
+        eventTicketStockRepository.findEventTicketStocksByEventIn(eventPaymentCountMap.keySet()).forEach(
+                eventTicketStock ->
+                        eventTicketStock.decreaseStock(eventPaymentCountMap.get(eventTicketStock.getEvent()))
+        );
     }
 }

--- a/src/main/java/com/spotlightspace/core/point/service/PointService.java
+++ b/src/main/java/com/spotlightspace/core/point/service/PointService.java
@@ -6,8 +6,6 @@ import com.spotlightspace.core.point.dto.request.CreatePointRequestDto;
 import com.spotlightspace.core.point.dto.response.CreatePointResponseDto;
 import com.spotlightspace.core.point.dto.response.GetPointResponseDto;
 import com.spotlightspace.core.point.repository.PointRepository;
-import com.spotlightspace.core.pointhistory.domain.PointHistory;
-import com.spotlightspace.core.pointhistory.repository.PointHistoryRepository;
 import com.spotlightspace.core.user.domain.User;
 import com.spotlightspace.core.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +19,6 @@ public class PointService {
 
     private final PointRepository pointRepository;
     private final UserRepository userRepository;
-    private final PointHistoryRepository pointHistoryRepository;
 
     @Transactional
     public CreatePointResponseDto createPoint(CreatePointRequestDto requestDto, AuthUser authUser) {
@@ -62,11 +59,5 @@ public class PointService {
     private User checkUserData(Long userId) {
 
         return userRepository.findByIdOrElseThrow(userId);
-    }
-
-    public void cancelPointUsage(Point point) {
-        PointHistory pointHistory = pointHistoryRepository.findByPointOrElseThrow(point);
-        point.cancelUsage(pointHistory.getAmount());
-        pointHistory.cancelPointUsage();
     }
 }

--- a/src/main/java/com/spotlightspace/core/pointhistory/repository/PointHistoryRepository.java
+++ b/src/main/java/com/spotlightspace/core/pointhistory/repository/PointHistoryRepository.java
@@ -3,6 +3,7 @@ package com.spotlightspace.core.pointhistory.repository;
 import static com.spotlightspace.common.exception.ErrorCode.POINT_HISTORY_NOT_FOUND;
 
 import com.spotlightspace.common.exception.ApplicationException;
+import com.spotlightspace.core.payment.domain.Payment;
 import com.spotlightspace.core.point.domain.Point;
 import com.spotlightspace.core.pointhistory.domain.PointHistory;
 import java.util.Optional;
@@ -10,11 +11,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
 
-    void deleteByPoint(Point point);
-
     Optional<PointHistory> findByPoint(Point point);
+
+    Optional<PointHistory> findByPayment(Payment payment);
 
     default PointHistory findByPointOrElseThrow(Point point) {
         return findByPoint(point).orElseThrow(() -> new ApplicationException(POINT_HISTORY_NOT_FOUND));
+    }
+
+    default PointHistory findByPaymentOrElseThrow(Payment payment) {
+        return findByPayment(payment).orElseThrow(() -> new ApplicationException(POINT_HISTORY_NOT_FOUND));
     }
 }

--- a/src/main/java/com/spotlightspace/core/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/spotlightspace/core/ticket/repository/TicketRepository.java
@@ -1,6 +1,12 @@
 package com.spotlightspace.core.ticket.repository;
 
+import static com.spotlightspace.common.exception.ErrorCode.TICKET_NOT_FOUND;
+
+import com.spotlightspace.common.exception.ApplicationException;
+import com.spotlightspace.core.event.domain.Event;
 import com.spotlightspace.core.ticket.domain.Ticket;
+import com.spotlightspace.core.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +19,9 @@ public interface TicketRepository extends JpaRepository<Ticket, Long>, TicketQue
     @Query("SELECT SUM(t.price) FROM Ticket t JOIN t.event e WHERE e.user.id = :userId AND e.isCalculated = false AND t.isCanceled = false")
     int findTotalAmountByUserId(@Param("userId") Long userId);
 
+    Optional<Ticket> findFirstByUserAndEvent(User user, Event event);
+
+    default Ticket findFirstByUserAndEventOrElseThrow(User user, Event event) {
+        return findFirstByUserAndEvent(user, event).orElseThrow(() -> new ApplicationException(TICKET_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/spotlightspace/core/ticket/service/TicketService.java
+++ b/src/main/java/com/spotlightspace/core/ticket/service/TicketService.java
@@ -28,6 +28,11 @@ public class TicketService {
         return TicketResponse.from(ticketRepository.save(ticket));
     }
 
+    public void cancelTicket(User user, Event event) {
+        Ticket ticket = ticketRepository.findFirstByUserAndEventOrElseThrow(user, event);
+        ticket.cancel();
+    }
+
     private boolean isNegativePrice(int price) {
         return price < 0;
     }

--- a/src/test/java/com/spotlightspace/core/payment/domain/PaymentTest.java
+++ b/src/test/java/com/spotlightspace/core/payment/domain/PaymentTest.java
@@ -2,13 +2,13 @@ package com.spotlightspace.core.payment.domain;
 
 import static com.spotlightspace.core.payment.domain.PaymentStatus.APPROVED;
 import static com.spotlightspace.core.payment.domain.PaymentStatus.PENDING;
-import static com.spotlightspace.core.payment.domain.PaymentStatus.READY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.spotlightspace.core.auth.dto.request.SignUpUserRequestDto;
 import com.spotlightspace.core.event.domain.Event;
 import com.spotlightspace.core.event.domain.EventCategory;
 import com.spotlightspace.core.event.dto.request.CreateEventRequestDto;
+import com.spotlightspace.core.point.domain.Point;
 import com.spotlightspace.core.user.domain.User;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +22,16 @@ class PaymentTest {
         // given
         User user = createUser();
         Event event = createEvent(user);
-        Payment payment = Payment.create("cid", event, user, 10_000, 10_000, null, null);
+        Payment payment = Payment.create(
+                "cid",
+                event,
+                user,
+                10_000,
+                10_000,
+                null,
+                Point.of(0, user),
+                0
+        );
 
         // when
         payment.approve();
@@ -37,7 +46,16 @@ class PaymentTest {
         // given
         User user = createUser();
         Event event = createEvent(user);
-        Payment payment = Payment.create("cid", event, user, 10_000, 10_000, null, null);
+        Payment payment = Payment.create(
+                "cid",
+                event,
+                user,
+                10_000,
+                10_000,
+                null,
+                null,
+                0
+        );
 
         // when & then
         assertThat(payment.getStatus()).isEqualTo(PENDING);


### PR DESCRIPTION
## #️⃣ 관련 이슈
- resolved: #103 
## 📝 작업 내용
- 결제 로직 수정
    - createPayment()시에 포인트 차감 및 쿠폰 사용 처리를 하지않고 approvePayment()에서 포인트 차감 및  쿠폰 사용 처리하도록 수정
- 결제 실패 시 재고 원상복구 기능 구현