### PR TITLE
[#118] 이벤트 조회 date 기준 정렬 패치 완

### DIFF
--- a/src/main/java/com/spotlightspace/core/event/repository/EventElasticQueryRepositoryImpl.java
+++ b/src/main/java/com/spotlightspace/core/event/repository/EventElasticQueryRepositoryImpl.java
@@ -15,6 +15,7 @@ import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.stereotype.Repository;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,6 +28,7 @@ public class EventElasticQueryRepositoryImpl implements EventElasticQueryReposit
     public Page<GetEventElasticResponseDto> searchElasticEvents(
             SearchEventRequestDto requestDto, String type, Pageable pageable) throws IOException {
 
+        LocalDateTime now = LocalDateTime.now();
         CriteriaQuery query = new CriteriaQuery(new Criteria());
 
         if (requestDto.getTitle() != null) {
@@ -59,6 +61,7 @@ public class EventElasticQueryRepositoryImpl implements EventElasticQueryReposit
             sort = Sort.by(Sort.Order.desc("price"));
         }
         if (type.equals("date")) {
+            query.addCriteria(Criteria.where("recruitmentFinishAt").greaterThanEqual(now));
             sort = Sort.by(Sort.Order.asc("recruitmentFinishAt"));
         }
 

--- a/src/main/java/com/spotlightspace/core/event/repository/EventQueryRepositoryImpl.java
+++ b/src/main/java/com/spotlightspace/core/event/repository/EventQueryRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,6 +24,7 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
     @Override
     public Page<GetEventResponseDto> searchEvents(SearchEventRequestDto requestDto, String type, Pageable pageable) {
         QEvent event = QEvent.event;
+        LocalDateTime now = LocalDateTime.now();
 
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(event.isDeleted.eq(false));
@@ -60,6 +62,7 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
                 orderSpecifier = event.price.desc();
                 break;
             case "date":
+                builder.and(event.recruitmentFinishAt.goe(now));
                 orderSpecifier = event.recruitmentFinishAt.asc();
                 break;
             default:


### PR DESCRIPTION
## #️⃣ 관련 이슈
- resolved : #118 
## 📝 작업 내용
- date 기준으로 정렬 시 현재 날짜 이전 데이터도 같이 가져오지 않도록 패치 완
- 엘라스틱 서치 코드도 마찬가지로 수정 완
