### PR TITLE
[#120] 유저 조회 인덱싱

### DIFF
--- a/src/main/generated/com/spotlightspace/core/user/domain/QUser.java
+++ b/src/main/generated/com/spotlightspace/core/user/domain/QUser.java
@@ -29,6 +29,8 @@ public class QUser extends EntityPathBase<User> {
 
     public final BooleanPath isSocialLogin = createBoolean("isSocialLogin");
 
+    public final StringPath location = createString("location");
+
     public final StringPath nickname = createString("nickname");
 
     public final StringPath password = createString("password");

--- a/src/main/java/com/spotlightspace/core/admin/controller/AdminUserController.java
+++ b/src/main/java/com/spotlightspace/core/admin/controller/AdminUserController.java
@@ -1,14 +1,21 @@
 package com.spotlightspace.core.admin.controller;
 
+import static com.spotlightspace.common.exception.ErrorCode.NO_RESULTS_FOUND;
+
 import com.spotlightspace.common.exception.ApplicationException;
+import com.spotlightspace.core.admin.dto.requestdto.SearchAdminUserRequestDto;
 import com.spotlightspace.core.admin.dto.responsedto.AdminUserResponseDto;
 import com.spotlightspace.core.admin.service.AdminUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import static com.spotlightspace.common.exception.ErrorCode.NO_RESULTS_FOUND;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,24 +24,41 @@ public class AdminUserController {
 
     private final AdminUserService adminUserService;
 
-
     /**
-     * @param page      조회할 페이지 번호 (1부터 시작)
-     * @param size      페이지 당 항목 수
-     * @param keyword   검색 키워드 (선택적)
-     * @param sortField 결과를 정렬할 필드명
-     * @param sortOrder 정렬 순서 (오름차순 또는 내림차순)
-     * @return {@link AdminUserResponseDto}의 페이지 형태로 검색 결과 반환
+     * 유저를 검색합니다
+     *
+     * @param page          조회할 페이지 번호 (1부터 시작)
+     * @param size          페이지 당 항목 수
+     * @param nickname      검색 키워드 : 닉네임 (선택적)
+     * @param email         검색 키워드 : 이메일 (선택적)
+     * @param phoneNumber   검색 키워드 : 전화번호 (선택적)
+     * @param role          검색 키워드 : 권한 아티스트 or 유저 (선택적)
+     * @param location      검색 키워드 : 지역 (선택적)
+     * @param isSocialLogin 검색 키워드 : 소셜 로그인 여부 (선택적)
+     * @param isDeleted     검색 키워드 : 삭제 여부 (선택적)
+     * @param sortField     결과를 정렬할 필드명
+     * @param sortOrder     정렬 순서 (오름차순 또는 내림차순)
+     * @return 페이지 형태로 검색 결과 반환
      */
     @GetMapping("/search")
     public ResponseEntity<Page<AdminUserResponseDto>> searchUsers(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String nickname,
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) String phoneNumber,
+            @RequestParam(required = false) String role,
+            @RequestParam(required = false) String location,
+            @RequestParam(required = false) String birth,
+            @RequestParam(defaultValue = "false") Boolean isSocialLogin,
+            @RequestParam(defaultValue = "false") Boolean isDeleted,
             @RequestParam(defaultValue = "id") String sortField,
             @RequestParam(defaultValue = "asc") String sortOrder
     ) {
-        Page<AdminUserResponseDto> users = adminUserService.getAdminUsers(page, size, keyword, sortField, sortOrder);
+        SearchAdminUserRequestDto searchAdminUserRequestDto = SearchAdminUserRequestDto.of(nickname, email, phoneNumber,
+                role, location, birth, isSocialLogin, isDeleted);
+        Page<AdminUserResponseDto> users = adminUserService.getAdminUsers(page, size, searchAdminUserRequestDto,
+                sortField, sortOrder);
         if (users.isEmpty()) {
             throw new ApplicationException(NO_RESULTS_FOUND);
         }

--- a/src/main/java/com/spotlightspace/core/admin/dto/requestdto/SearchAdminUserRequestDto.java
+++ b/src/main/java/com/spotlightspace/core/admin/dto/requestdto/SearchAdminUserRequestDto.java
@@ -1,0 +1,35 @@
+package com.spotlightspace.core.admin.dto.requestdto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchAdminUserRequestDto {
+
+    private String nickname;
+    private String email;
+    private String phoneNumber;
+    private String role;
+    private String location;
+    private String birth;
+    private boolean isSocialLogin;
+    private boolean isDeleted;
+
+    public static SearchAdminUserRequestDto of(
+            String nickname,
+            String email,
+            String phoneNumber,
+            String role,
+            String location,
+            String birth,
+            boolean isSocialLogin,
+            boolean isDeleted
+    ) {
+        return new SearchAdminUserRequestDto(nickname, email, phoneNumber, role, location, birth, isSocialLogin, isDeleted);
+    }
+
+}

--- a/src/main/java/com/spotlightspace/core/admin/repository/AdminQueryRepository.java
+++ b/src/main/java/com/spotlightspace/core/admin/repository/AdminQueryRepository.java
@@ -1,6 +1,7 @@
 package com.spotlightspace.core.admin.repository;
 
 import com.querydsl.core.Tuple;
+import com.spotlightspace.core.admin.dto.requestdto.SearchAdminUserRequestDto;
 import com.spotlightspace.core.admin.dto.responsedto.AdminCouponResponseDto;
 import com.spotlightspace.core.admin.dto.responsedto.AdminEventResponseDto;
 import com.spotlightspace.core.admin.dto.responsedto.AdminReviewResponseDto;
@@ -9,15 +10,15 @@ import com.spotlightspace.core.coupon.domain.Coupon;
 import com.spotlightspace.core.event.domain.Event;
 import com.spotlightspace.core.review.domain.Review;
 import com.spotlightspace.core.user.domain.User;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-import java.util.Optional;
-
 
 public interface AdminQueryRepository {
-    Page<AdminUserResponseDto> getAdminUsers(String keyword, Pageable pageable);
+
+    Page<AdminUserResponseDto> getAdminUsers(SearchAdminUserRequestDto searchAdminUserRequestDto, Pageable pageable);
 
     Page<AdminEventResponseDto> getAdminEvents(String keyword, Pageable pageable);
 

--- a/src/main/java/com/spotlightspace/core/admin/service/AdminUserService.java
+++ b/src/main/java/com/spotlightspace/core/admin/service/AdminUserService.java
@@ -1,6 +1,9 @@
 package com.spotlightspace.core.admin.service;
 
+import static com.spotlightspace.common.exception.ErrorCode.USER_NOT_FOUND;
+
 import com.spotlightspace.common.exception.ApplicationException;
+import com.spotlightspace.core.admin.dto.requestdto.SearchAdminUserRequestDto;
 import com.spotlightspace.core.admin.dto.responsedto.AdminUserResponseDto;
 import com.spotlightspace.core.admin.repository.AdminQueryRepository;
 import com.spotlightspace.core.user.domain.User;
@@ -13,8 +16,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.spotlightspace.common.exception.ErrorCode.USER_NOT_FOUND;
-
 
 @Service
 @RequiredArgsConstructor
@@ -24,16 +25,24 @@ public class AdminUserService {
     private final AdminQueryRepository adminRepository;
 
     @Transactional(readOnly = true)
-    public Page<AdminUserResponseDto> getAdminUsers(int page, int size, String keyword, String sortField, String sortOrder) {
-        Sort sort = Sort.by(sortField);
-        if ("desc".equalsIgnoreCase(sortOrder)) {
+    public Page<AdminUserResponseDto> getAdminUsers(
+            int page,
+            int size,
+            SearchAdminUserRequestDto searchAdminUserRequestDto,
+            String field,
+            String order
+    ) {
+
+        Sort sort = Sort.by(field);
+
+        if ("desc".equalsIgnoreCase(order)) {
             sort = sort.descending();
         } else {
             sort = sort.ascending();
         }
 
         Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, sort);
-        return adminRepository.getAdminUsers(keyword, pageable);
+        return adminRepository.getAdminUsers(searchAdminUserRequestDto, pageable);
     }
 
     @Transactional

--- a/src/main/java/com/spotlightspace/core/auth/dto/request/SignUpUserRequestDto.java
+++ b/src/main/java/com/spotlightspace/core/auth/dto/request/SignUpUserRequestDto.java
@@ -38,5 +38,7 @@ public class SignUpUserRequestDto {
             message = "휴대폰 번호는 010-0000-0000 형식이어야 합니다."
     )
     private String phoneNumber;
+
+    private String location;
 }
 

--- a/src/main/java/com/spotlightspace/core/auth/service/AuthService.java
+++ b/src/main/java/com/spotlightspace/core/auth/service/AuthService.java
@@ -126,7 +126,7 @@ public class AuthService {
         password = passwordEncoder.encode(password);
         String birth = LocalDate.now().toString();
         SignUpUserRequestDto signupUserRequestDto = new SignUpUserRequestDto(email, password, nickname, "ROLE_USER",
-                birth, true, id.toString());
+                birth, true, id.toString(), "한국");
         User user = User.of(password, signupUserRequestDto);
 
         User savedUser = userRepository.save(user);
@@ -144,7 +144,7 @@ public class AuthService {
         String birth = LocalDate.now().toString();
 
         SignUpUserRequestDto signupUserRequestDto = new SignUpUserRequestDto(email, password, nickname, "ROLE_USER",
-                birth, true, mobile);
+                birth, true, mobile, "한국");
 
         User user = User.of(password, signupUserRequestDto);
 

--- a/src/main/java/com/spotlightspace/core/user/domain/User.java
+++ b/src/main/java/com/spotlightspace/core/user/domain/User.java
@@ -2,12 +2,18 @@ package com.spotlightspace.core.user.domain;
 
 import com.spotlightspace.core.auth.dto.request.SignUpUserRequestDto;
 import com.spotlightspace.core.user.dto.request.UpdateUserRequestDto;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,11 +53,22 @@ public class User {
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
+    @NotNull
+    private String location;
+
     private boolean isDeleted = false;
     private boolean isSocialLogin;
 
-    private User(String email, String nickname, String password, UserRole role, LocalDate birth, String phoneNumber,
-                 boolean isSocialLogin) {
+    private User(
+            String email,
+            String nickname,
+            String password,
+            UserRole role,
+            LocalDate birth,
+            String phoneNumber,
+            boolean isSocialLogin,
+            String location
+    ) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
@@ -59,6 +76,7 @@ public class User {
         this.birth = birth;
         this.phoneNumber = phoneNumber;
         this.isSocialLogin = isSocialLogin;
+        this.location = location;
     }
 
     public static User of(String encryptPassword, SignUpUserRequestDto signupUserRequestDto) {
@@ -69,7 +87,8 @@ public class User {
                 UserRole.from(signupUserRequestDto.getRole()),
                 LocalDate.parse(signupUserRequestDto.getBirth(), DateTimeFormatter.ofPattern("yyyy-MM-dd")),
                 signupUserRequestDto.getPhoneNumber(),
-                signupUserRequestDto.isSocialLogin()
+                signupUserRequestDto.isSocialLogin(),
+                signupUserRequestDto.getLocation()
         );
     }
 
@@ -78,6 +97,7 @@ public class User {
         this.birth = LocalDate.parse(updateUserRequestDto.getBirth(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         this.phoneNumber = updateUserRequestDto.getPhoneNumber();
         this.password = encryptPassword;
+        this.location = updateUserRequestDto.getLocation();
     }
 
     public void delete() {

--- a/src/main/java/com/spotlightspace/core/user/domain/User.java
+++ b/src/main/java/com/spotlightspace/core/user/domain/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -20,10 +21,18 @@ import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Entity
-@Table(name = "users")
 @Getter
 @Service
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_nickname_phone", columnList = "phone_number, nickname"),
+                @Index(name = "idx_nickname_birth", columnList = "nickname, birth"),
+                @Index(name = "idx_location", columnList = "location, nickname")
+        }
+)
+
 public class User {
 
     @Id
@@ -130,3 +139,4 @@ public class User {
     }
 
 }
+

--- a/src/main/java/com/spotlightspace/core/user/dto/request/UpdateUserRequestDto.java
+++ b/src/main/java/com/spotlightspace/core/user/dto/request/UpdateUserRequestDto.java
@@ -28,4 +28,6 @@ public class UpdateUserRequestDto {
             message = "휴대폰 번호는 010-0000-0000 형식이어야 합니다."
     )
     private String phoneNumber;
+
+    private String location;
 }

--- a/src/test/java/com/spotlightspace/core/data/UserTestData.java
+++ b/src/test/java/com/spotlightspace/core/data/UserTestData.java
@@ -53,7 +53,7 @@ public class UserTestData {
     }
 
     public static UpdateUserRequestDto testUpdateUserRequestDto() {
-        return new UpdateUserRequestDto("email@test.com", "newPassword", "2024-10-21", "newPhone", null);
+        return new UpdateUserRequestDto("email@test.com", "newPassword", "2024-10-21", "newPhone", "한국");
     }
 
     //authUser

--- a/src/test/java/com/spotlightspace/core/data/UserTestData.java
+++ b/src/test/java/com/spotlightspace/core/data/UserTestData.java
@@ -22,7 +22,8 @@ public class UserTestData {
                 "ROLE_USER",
                 "2024-10-24",
                 false,
-                "010-1010-1010");
+                "010-1010-1010",
+                "한국");
     }
 
     public static SignUpUserRequestDto testSignupArtistRequestDto() {
@@ -33,7 +34,8 @@ public class UserTestData {
                 "ROLE_ARTIST",
                 "2024-10-24",
                 false,
-                "010-1010-1010");
+                "010-1010-1010",
+                "한국");
     }
 
     public static User testUser() {
@@ -51,7 +53,7 @@ public class UserTestData {
     }
 
     public static UpdateUserRequestDto testUpdateUserRequestDto() {
-        return new UpdateUserRequestDto("email@test.com", "newPassword", "2024-10-21", "newPhone");
+        return new UpdateUserRequestDto("email@test.com", "newPassword", "2024-10-21", "newPhone", null);
     }
 
     //authUser

--- a/src/test/java/com/spotlightspace/core/payment/domain/PaymentTest.java
+++ b/src/test/java/com/spotlightspace/core/payment/domain/PaymentTest.java
@@ -70,7 +70,8 @@ class PaymentTest {
                 "role_user",
                 "1998-12-12",
                 false,
-                "010-1234-1234"
+                "010-1234-1234",
+                "한국"
         );
         return User.of("encryptPassword", requestDto);
     }

--- a/src/test/java/com/spotlightspace/core/ticket/service/TicketServiceTest.java
+++ b/src/test/java/com/spotlightspace/core/ticket/service/TicketServiceTest.java
@@ -107,7 +107,8 @@ class TicketServiceTest {
                 "role_user",
                 "1998-12-12",
                 false,
-                "010-1234-1234"
+                "010-1234-1234",
+                "한국"
         );
         return userRepository.save(User.of("encryptPassword", requestDto));
     }
@@ -120,7 +121,8 @@ class TicketServiceTest {
                 "role_artist",
                 "1998-12-12",
                 false,
-                "010-4321-1234"
+                "010-4321-1234",
+                "한국"
         );
         return userRepository.save(User.of("encryptPassword", requestDto));
     }


### PR DESCRIPTION
## #️⃣ 관련 이슈
- resolved : #120

## 📝 작업 내용
- 유저 조회에 인덱싱을 적용하였습니다
- 300만건의 무작위 유저 데이터가 존재할때
- 이름, 전화번호, 생일 조회시 3.22s 에서 1219ms로 62퍼센트 개선하였습니다.